### PR TITLE
Modified client.go to use interface that supports http.Do, allowing multiple Client types.

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,9 +22,7 @@ type RequestDoer interface {
 // Client embeds http.Client and provides a convenient way to make JSON-RPC
 // requests.
 type Client struct {
-
-	RequestDoer RequestDoer
-
+	RequestDoer
 	DebugRequest bool
 	Log          Logger
 
@@ -84,8 +82,9 @@ func (c *Client) Request(url, method string, params, result interface{}) error {
 	if c.BasicAuth {
 		req.SetBasicAuth(c.User, c.Password)
 	}
+
 	// Make the request.
-	res, err := c.RequestDoer.Do(req)
+	res, err := c.Do(req)
 	if err != nil {
 		return err
 	}
@@ -128,5 +127,4 @@ func NewClient(doer RequestDoer) *Client {
 		doer = &http.Client{}
 	}
 	return &Client{RequestDoer: doer}
-
 }

--- a/client.go
+++ b/client.go
@@ -22,7 +22,8 @@ type RequestDoer interface {
 // Client embeds http.Client and provides a convenient way to make JSON-RPC
 // requests.
 type Client struct {
-	Client RequestDoer
+
+	RequestDoer RequestDoer
 
 	DebugRequest bool
 	Log          Logger
@@ -56,9 +57,6 @@ type Client struct {
 // stdout.
 func (c *Client) Request(url, method string, params, result interface{}) error {
 	// Generate a random ID for this request.
-	if c.Client == nil {
-		c.Client = NewClient(nil)
-	}
 	reqID := rand.Uint32()%200 + 500
 
 	// Marshal the JSON RPC Request.
@@ -87,7 +85,7 @@ func (c *Client) Request(url, method string, params, result interface{}) error {
 		req.SetBasicAuth(c.User, c.Password)
 	}
 	// Make the request.
-	res, err := c.Client.Do(req)
+	res, err := c.RequestDoer.Do(req)
 	if err != nil {
 		return err
 	}
@@ -124,9 +122,11 @@ func (c *Client) Request(url, method string, params, result interface{}) error {
 	return nil
 }
 
-func NewClient(doer RequestDoer) RequestDoer {
+
+func NewClient(doer RequestDoer) *Client {
 	if doer == nil {
-		return http.DefaultClient
+		doer = &http.Client{}
 	}
-	return doer
+	return &Client{RequestDoer: doer}
+
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/AdamSLevy/jsonrpc2/v11
 
-go 1.12
+go 1.13
 
-require (
-	github.com/hashicorp/go-retryablehttp v0.6.2
-	github.com/stretchr/testify v1.3.0
-)
+require github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/AdamSLevy/jsonrpc2/v11
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.2
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
-github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
-github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs52eiUS9nSiw=
-github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,15 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs52eiUS9nSiw=
+github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Headers retain the same, but client supports retryable functionality. I am using the package defaults for now.