### PR TITLE
Allow use of custom error messages with `ErrorCodeInvalidParams`.

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -113,8 +113,10 @@ func (method MethodFunc) call(ctx context.Context,
 			// InvalidParamsCode is the only reserved ErrorCode
 			// MethodFuncs are allowed to return.
 			if methodErr.Code == ErrorCodeInvalidParams {
-				// Ensure the correct message is used.
-				methodErr.Message = ErrorMessageInvalidParams
+				if methodErr.Message == "" {
+					// Ensure the correct message is used if none is supplied.
+					methodErr.Message = ErrorMessageInvalidParams
+				}
 			} else if methodErr.Code.IsReserved() {
 				panic(fmt.Errorf("invalid use of %v", methodErr.Code))
 			}
@@ -153,7 +155,7 @@ func (method MethodFunc) call(ctx context.Context,
 	// that here.
 	data, err := json.Marshal(result)
 	if err != nil {
-		panic(fmt.Sprintf("json.Marshal(result): %w", err))
+		panic(fmt.Errorf("json.Marshal(result): %w", err))
 	}
 	res.Result = json.RawMessage(data)
 	return

--- a/methods_test.go
+++ b/methods_test.go
@@ -123,4 +123,17 @@ func TestMethodFuncCall(t *testing.T) {
 	}
 	assert.Nil(res.Result)
 	assert.Empty(string(buf.Bytes()))
+
+	// Ensure the default error message is used for ErrorCodeInvalidParams, even
+	// if the implementation does not provide a message.
+	f = func(_ context.Context, _ json.RawMessage) interface{} {
+		return NewError(ErrorCodeInvalidParams, "", "data")
+	}
+	res = f.call(context.Background(), "", nil, lgr)
+	if assert.NotNil(res.Error) {
+		e := ErrorInvalidParams(json.RawMessage(`"data"`))
+		assert.Equal(e, res.Error)
+	}
+	assert.Nil(res.Result)
+	assert.Empty(string(buf.Bytes()))
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -136,4 +136,15 @@ func TestMethodFuncCall(t *testing.T) {
 	}
 	assert.Nil(res.Result)
 	assert.Empty(string(buf.Bytes()))
+
+	// Ensure a custom error message is retained for ErrorCodeInvalidParams.
+	f = func(_ context.Context, _ json.RawMessage) interface{} {
+		return NewError(ErrorCodeInvalidParams, "a custom error message", "data")
+	}
+	res = f.call(context.Background(), "", nil, lgr)
+	if assert.NotNil(res.Error) {
+		assert.Equal("a custom error message", res.Error.Message)
+	}
+	assert.Nil(res.Result)
+	assert.Empty(string(buf.Bytes()))
 }


### PR DESCRIPTION
This PR relaxes the requirement that JSON-RPC errors with a code of `ErrorCodeInvalidParams` use `ErrorMessageInvalidParams` unconditionally. It retains the use of this error message if no message is supplied by the server implementation at all.

I was unable to add the `methodErr.Message == ""` condition to the existing `if` statement, as that would cause execution of the `if methodErr.Code.IsReserved()` block.

I also had to change the `Sprintf()` on line 158 to `Errorf()` in order for the tests to pass, as `go test` now executes `vet` as well, and the build was failing with an `Sprintf call has error-wrapping directive %w` error.

Fixes #6

/cc @CWX-iggy